### PR TITLE
Empty blob filename is now properly handled in opal_upload

### DIFF
--- a/opal-python-client/src/main/python/scripts/opal_upload
+++ b/opal-python-client/src/main/python/scripts/opal_upload
@@ -205,6 +205,8 @@ class OpalFile:
                                          .format(line[0], header[max_bin], self.name, reader.line_num))
                 for idx in binary_columns:
                     blob = line[idx]
+                    if not blob:
+                        continue #blob filename value is empty: skip it
                     # Don't re-upload a file if it was already uploaded
                     if blob in self.binary_files:
                         continue


### PR DESCRIPTION
This fixes a problem i found when importing data on a table with a variable blog, and we have rows whose blog value (filename) is empty. Now those will be correctly ignored
