### PR TITLE
Suppress warn

### DIFF
--- a/opal-python-client/pom.xml
+++ b/opal-python-client/pom.xml
@@ -379,6 +379,9 @@
                                   if [ -d $python_lib ]; then
                                       rm -f $python_lib/opal
                                   fi
+                                  if [ -L $python_lib/opal_tools_lib.py ]; then
+                                    unlink $python_lib/opal_tools_lib.py
+                                  fi 
                                   ln -s /usr/share/pyshared/opal $python_lib/opal
                                   ln -s /usr/share/pyshared/opal_tools_lib.py $python_lib/opal_tools_lib.py
                               </script>

--- a/opal-python-client/pom.xml
+++ b/opal-python-client/pom.xml
@@ -381,7 +381,7 @@
                                   fi
                                   if [ -L $python_lib/opal_tools_lib.py ]; then
                                     unlink $python_lib/opal_tools_lib.py
-                                  fi 
+                                  fi
                                   ln -s /usr/share/pyshared/opal $python_lib/opal
                                   ln -s /usr/share/pyshared/opal_tools_lib.py $python_lib/opal_tools_lib.py
                               </script>


### PR DESCRIPTION
suppress warning while deploying
Updating   : opal-python-client-2.5.16-1.noarch                                                          1/2
ln: creating symbolic link `/usr/lib/python2.6/site-packages/opal_tools_lib.py': File exists
warning: %post(opal-python-client-2.5.16-1.noarch) scriptlet failed, exit status 1
Non-fatal POSTIN scriptlet failure in rpm package opal-python-client-2.5.16-1.noarch
